### PR TITLE
Prevents the CLI from storing Cloudflare API tokens as plaintext in `store.json`.

### DIFF
--- a/internal/app.go
+++ b/internal/app.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -126,31 +127,126 @@ func PromptWizard(logger *Logger) bool {
 	}
 }
 
-func PromptLogin(logger *Logger, total int) int {
-	reader := bufio.NewReader(os.Stdin)
+type LoginAction int
+
+const (
+	LoginSelect LoginAction = iota
+	LoginAdd
+	LoginRemove
+)
+
+type LoginChoice struct {
+	Action LoginAction
+	Index  int
+}
+
+func PromptLogin(logger *Logger, total int) LoginChoice {
+	return promptLogin(logger, os.Stdin, os.Stdout, total)
+}
+
+func promptLogin(logger *Logger, input io.Reader, output io.Writer, total int) LoginChoice {
+	reader := bufio.NewReader(input)
 	for {
-		fmt.Println()
-		fmt.Printf("%s Choose a Cloudflare account [Default: active]: ", FmtStr(">", ColorBlue, true))
+		fmt.Fprintln(output)
+		fmt.Fprintf(output, "%s Choose a Cloudflare account [Default: active]: ", FmtStr(">", ColorBlue, true))
 		line, err := reader.ReadString('\n')
 		if err != nil {
 			logger.Fatal(err)
 		}
-		resp := strings.TrimSpace(line)
+		resp := strings.ToLower(strings.TrimSpace(line))
 		if resp == "" {
-			return 1
+			return LoginChoice{Action: LoginSelect, Index: -1}
 		}
-
+		if resp == "0" {
+			return LoginChoice{Action: LoginAdd}
+		}
 		number, err := strconv.Atoi(resp)
 		if err != nil {
-			logger.Fatal(err)
+			logger.Error("Invalid choice, try again...")
+			continue
 		}
 
-		if number > total {
+		if number == total+1 {
+			return LoginChoice{Action: LoginRemove}
+		}
+		if number < 1 || number > total {
 			logger.Error("Out of range, try again...")
 			continue
 		}
 
-		return number
+		return LoginChoice{Action: LoginSelect, Index: number - 1}
+	}
+}
+
+func PromptLoginRemoval(logger *Logger, logins []CfLogin) (int, bool) {
+	return promptLoginRemoval(logger, os.Stdin, os.Stdout, logins)
+}
+
+func promptLoginRemoval(logger *Logger, input io.Reader, output io.Writer, logins []CfLogin) (int, bool) {
+	reader := bufio.NewReader(input)
+	for {
+		fmt.Fprintln(output)
+		for index, login := range logins {
+			fmt.Fprintf(output, "  %s %s\n", FmtStr(fmt.Sprintf("%d.", index+1), ColorBlue, true), login.Email)
+		}
+		fmt.Fprintf(output, "%s Choose an account to remove [c to cancel]: ", FmtStr(">", ColorBlue, true))
+
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			logger.Fatal(err)
+		}
+		resp := strings.ToLower(strings.TrimSpace(line))
+		if resp == "c" {
+			return 0, false
+		}
+
+		number, err := strconv.Atoi(resp)
+		if err != nil || number < 1 || number > len(logins) {
+			logger.Error("Out of range, try again...")
+			continue
+		}
+		return number - 1, true
+	}
+}
+
+func ConfirmTokenRemoval(logger *Logger, email string) bool {
+	return confirmTokenRemoval(logger, os.Stdin, os.Stdout, email)
+}
+
+func confirmTokenRemoval(logger *Logger, input io.Reader, output io.Writer, email string) bool {
+	return promptYesNo(
+		logger,
+		input,
+		output,
+		fmt.Sprintf("Remove the saved token for %s [y/n]: ", email),
+	)
+}
+
+func PromptAddAccount(logger *Logger) bool {
+	return promptAddAccount(logger, os.Stdin, os.Stdout)
+}
+
+func promptAddAccount(logger *Logger, input io.Reader, output io.Writer) bool {
+	return promptYesNo(logger, input, output, "No saved accounts remain. Add a new account [y/n]: ")
+}
+
+func promptYesNo(logger *Logger, input io.Reader, output io.Writer, prompt string) bool {
+	reader := bufio.NewReader(input)
+	for {
+		fmt.Fprintln(output)
+		fmt.Fprintf(output, "%s %s", FmtStr(">", ColorBlue, true), prompt)
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			logger.Fatal(err)
+		}
+		switch strings.ToLower(strings.TrimSpace(line)) {
+		case "y":
+			return true
+		case "n":
+			return false
+		default:
+			logger.Error("Only 'y' or 'n', try again...")
+		}
 	}
 }
 

--- a/internal/app_test.go
+++ b/internal/app_test.go
@@ -1,0 +1,53 @@
+package internal
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestPromptLoginActions(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		wantAction LoginAction
+		wantIndex  int
+	}{
+		{name: "default", input: "\n", wantAction: LoginSelect, wantIndex: -1},
+		{name: "select", input: "2\n", wantAction: LoginSelect, wantIndex: 1},
+		{name: "add", input: "0\n", wantAction: LoginAdd},
+		{name: "remove", input: "3\n", wantAction: LoginRemove},
+		{name: "retry invalid", input: "-1\n1\n", wantAction: LoginSelect, wantIndex: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var output bytes.Buffer
+			logger := newLogger(&output)
+			got := promptLogin(logger, strings.NewReader(tt.input), &output, 2)
+			if got.Action != tt.wantAction || got.Index != tt.wantIndex {
+				t.Fatalf("got %#v, want action %v index %d", got, tt.wantAction, tt.wantIndex)
+			}
+		})
+	}
+}
+
+func TestRemovalPrompts(t *testing.T) {
+	logins := []CfLogin{
+		{Email: "one@example.com"},
+		{Email: "two@example.com"},
+	}
+	var output bytes.Buffer
+	logger := newLogger(&output)
+
+	index, ok := promptLoginRemoval(logger, strings.NewReader("bad\n2\n"), &output, logins)
+	if !ok || index != 1 {
+		t.Fatalf("got index %d, ok %v; want index 1", index, ok)
+	}
+	if confirmTokenRemoval(logger, strings.NewReader("n\n"), &output, logins[index].Email) {
+		t.Fatal("expected removal confirmation to be declined")
+	}
+	if !promptAddAccount(logger, strings.NewReader("y\n"), &output) {
+		t.Fatal("expected add-account prompt to be accepted")
+	}
+}

--- a/internal/logger.go
+++ b/internal/logger.go
@@ -2,28 +2,33 @@ package internal
 
 import (
 	"fmt"
+	"io"
 	"os"
 )
 
 type Logger struct {
-	color bool
+	color  bool
+	writer io.Writer
 }
 
 func NewLogger() *Logger {
-	return &Logger{color: true}
+	return newLogger(os.Stdout)
+}
+
+func newLogger(writer io.Writer) *Logger {
+	return &Logger{color: true, writer: writer}
 }
 
 func (l *Logger) Info(msg string) {
-	fmt.Printf("%s %s\n", FmtStr("•", ColorBlue, true), msg)
+	fmt.Fprintf(l.writer, "%s %s\n", FmtStr("•", ColorBlue, true), msg)
 }
 
 func (l *Logger) Success(msg string) {
-	
-	fmt.Printf("%s %s\n", FmtStr("✓", ColorGreen, true), msg)
+	fmt.Fprintf(l.writer, "%s %s\n", FmtStr("✓", ColorGreen, true), msg)
 }
 
 func (l *Logger) Error(msg string) {
-	fmt.Printf("%s %s\n", FmtStr("✗", ColorRed, true), msg)
+	fmt.Fprintf(l.writer, "%s %s\n", FmtStr("✗", ColorRed, true), msg)
 }
 
 func (l *Logger) Fatal(err error) {

--- a/internal/token_store.go
+++ b/internal/token_store.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -20,29 +21,49 @@ type CfLogin struct {
 	Token string `json:"token"`
 }
 
-type tokenStore struct{}
+type tokenStore struct {
+	path string
+}
+
 func NewTokenStore() tokenStore {
-	return tokenStore{}
+	return tokenStore{path: tokenFilePath()}
+}
+
+func newTokenStore(path string) tokenStore {
+	return tokenStore{path: path}
 }
 
 func (s tokenStore) LoadLogins() (cfLoginStore, error) {
-	data, err := os.ReadFile(tokenFilePath())
-	if err != nil || os.IsNotExist(err) {
+	data, err := os.ReadFile(s.path)
+	if os.IsNotExist(err) {
 		return cfLoginStore{}, nil
+	}
+	if err != nil {
+		return cfLoginStore{}, fmt.Errorf("read token store: %w", err)
 	}
 	if strings.TrimSpace(string(data)) == "" {
 		return cfLoginStore{}, nil
 	}
 
 	var store cfLoginStore
-	if err := json.Unmarshal(data, &store); err == nil && len(store.Logins) > 0 {
+	if err := json.Unmarshal(data, &store); err != nil {
+		return cfLoginStore{}, fmt.Errorf("decode token store: %w", err)
+	}
+	if len(store.Logins) == 0 {
+		store.ActiveEmail = ""
 		return store, nil
 	}
-
-	return cfLoginStore{
-		ActiveEmail: "",
-		Logins:      []CfLogin{},
-	}, nil
+	activeFound := false
+	for _, login := range store.Logins {
+		if login.Email == store.ActiveEmail {
+			activeFound = true
+			break
+		}
+	}
+	if !activeFound {
+		store.ActiveEmail = store.Logins[0].Email
+	}
+	return store, nil
 }
 
 func (s tokenStore) SaveLogin(login CfLogin) error {
@@ -67,13 +88,47 @@ func (s tokenStore) SaveLogin(login CfLogin) error {
 	return s.createStore(store)
 }
 
+func (s tokenStore) DeleteLogin(email string) (cfLoginStore, error) {
+	store, err := s.LoadLogins()
+	if err != nil {
+		return cfLoginStore{}, err
+	}
+
+	index := -1
+	for i, login := range store.Logins {
+		if login.Email == email {
+			index = i
+			break
+		}
+	}
+	if index == -1 {
+		return cfLoginStore{}, fmt.Errorf("saved account %q was not found", email)
+	}
+
+	store.Logins = append(store.Logins[:index], store.Logins[index+1:]...)
+	if len(store.Logins) == 0 {
+		if err := os.Remove(s.path); err != nil && !os.IsNotExist(err) {
+			return cfLoginStore{}, fmt.Errorf("remove token store: %w", err)
+		}
+		store.ActiveEmail = ""
+		return store, nil
+	}
+	if store.ActiveEmail == email {
+		store.ActiveEmail = store.Logins[0].Email
+	}
+	if err := s.createStore(store); err != nil {
+		return cfLoginStore{}, err
+	}
+	return store, nil
+}
+
 func (s tokenStore) createStore(store cfLoginStore) error {
 	data, err := json.MarshalIndent(store, "", "  ")
 	if err != nil {
 		return err
 	}
 
-	path := tokenFilePath()
+	path := s.path
 	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
 		return err
 	}

--- a/internal/token_store_test.go
+++ b/internal/token_store_test.go
@@ -1,0 +1,94 @@
+package internal
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDeleteLogin(t *testing.T) {
+	tests := []struct {
+		name       string
+		active     string
+		remove     string
+		wantActive string
+		wantLogins int
+	}{
+		{
+			name:       "non-active account",
+			active:     "one@example.com",
+			remove:     "two@example.com",
+			wantActive: "one@example.com",
+			wantLogins: 1,
+		},
+		{
+			name:       "active account",
+			active:     "one@example.com",
+			remove:     "one@example.com",
+			wantActive: "two@example.com",
+			wantLogins: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "store.json")
+			store := newTokenStore(path)
+			if err := store.createStore(cfLoginStore{
+				ActiveEmail: tt.active,
+				Logins: []CfLogin{
+					{Email: "one@example.com", ID: "one", Token: "token-one"},
+					{Email: "two@example.com", ID: "two", Token: "token-two"},
+				},
+			}); err != nil {
+				t.Fatal(err)
+			}
+
+			got, err := store.DeleteLogin(tt.remove)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(got.Logins) != tt.wantLogins {
+				t.Fatalf("got %d logins, want %d", len(got.Logins), tt.wantLogins)
+			}
+			if got.ActiveEmail != tt.wantActive {
+				t.Fatalf("got active email %q, want %q", got.ActiveEmail, tt.wantActive)
+			}
+		})
+	}
+}
+
+func TestDeleteFinalLoginRemovesStore(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "store.json")
+	store := newTokenStore(path)
+	if err := store.createStore(cfLoginStore{
+		ActiveEmail: "one@example.com",
+		Logins: []CfLogin{
+			{Email: "one@example.com", ID: "one", Token: "token-one"},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := store.DeleteLogin("one@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Logins) != 0 || got.ActiveEmail != "" {
+		t.Fatalf("expected an empty store, got %#v", got)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("expected store file to be removed, stat error: %v", err)
+	}
+}
+
+func TestLoadLoginsRejectsMalformedJSON(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "store.json")
+	if err := os.WriteFile(path, []byte("{"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := newTokenStore(path).LoadLogins(); err == nil {
+		t.Fatal("expected malformed JSON to return an error")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -40,7 +40,7 @@ func main() {
 	internal.ConfigTermux(logger)
 
 	header := fmt.Sprintf(`
- _____ _____ _____ 
+ _____ _____ _____
 | __  |  _  | __  |
 | __ -|   __| __ -|
 |_____|__|  |_____| Wizard CLI %s
@@ -53,41 +53,78 @@ func main() {
 		if err != nil {
 			logger.Fatal(err)
 		}
-		noStore := store.ActiveEmail == ""
-
 		var acc *internal.CfAccount
-		if noStore {
+		if len(store.Logins) == 0 {
 			acc = internal.CreateAccount(ctx, logger)
-			tokenStore.SaveLogin(internal.CfLogin{
+			if err := tokenStore.SaveLogin(internal.CfLogin{
 				Email: acc.Email,
 				ID:    acc.ID,
 				Token: acc.Token,
-			})
-		} else {
-			fmt.Println()
-			for index, account := range store.Logins {
-				counter := fmt.Sprintf("  %d.", index+1)
-				active := ""
-				if account.Email == store.ActiveEmail {
-					active = internal.FmtStr("[active]", internal.ColorGreen, true)
-				}
-
-				fmt.Printf("%s %s %s\n", internal.FmtStr(counter, internal.ColorBlue, true), account.Email, active)
+			}); err != nil {
+				logger.Fatal(err)
 			}
-			fmt.Printf("  %s Add a new token\n", internal.FmtStr("0.", internal.ColorBlue, true))
+		} else {
+			for acc == nil {
+				fmt.Println()
+				activeIndex := 0
+				for index, account := range store.Logins {
+					counter := fmt.Sprintf("  %d.", index+1)
+					active := ""
+					if account.Email == store.ActiveEmail {
+						activeIndex = index
+						active = internal.FmtStr("[active]", internal.ColorGreen, true)
+					}
 
-			index := internal.PromptLogin(logger, len(store.Logins))
-			if index == 0 {
-				acc = internal.CreateAccount(ctx, logger)
-				tokenStore.SaveLogin(internal.CfLogin{
-					Email: acc.Email,
-					ID:    acc.ID,
-					Token: acc.Token,
-				})
-			} else {
-				acc = internal.NewCfAccount(store.Logins[index-1].Token)
-				acc.ID = store.Logins[index-1].ID
-				acc.Email = store.Logins[index-1].Email
+					fmt.Printf("%s %s %s\n", internal.FmtStr(counter, internal.ColorBlue, true), account.Email, active)
+				}
+				fmt.Printf("  %s Add a new token\n", internal.FmtStr("0.", internal.ColorBlue, true))
+				removeCounter := fmt.Sprintf("%d.", len(store.Logins)+1)
+				fmt.Printf("  %s Remove a saved token\n", internal.FmtStr(removeCounter, internal.ColorBlue, true))
+
+				choice := internal.PromptLogin(logger, len(store.Logins))
+				switch choice.Action {
+				case internal.LoginAdd:
+					acc = internal.CreateAccount(ctx, logger)
+					if err := tokenStore.SaveLogin(internal.CfLogin{
+						Email: acc.Email,
+						ID:    acc.ID,
+						Token: acc.Token,
+					}); err != nil {
+						logger.Fatal(err)
+					}
+				case internal.LoginRemove:
+					index, ok := internal.PromptLoginRemoval(logger, store.Logins)
+					if !ok || !internal.ConfirmTokenRemoval(logger, store.Logins[index].Email) {
+						continue
+					}
+					store, err = tokenStore.DeleteLogin(store.Logins[index].Email)
+					if err != nil {
+						logger.Fatal(err)
+					}
+					logger.Success("Saved token removed successfully!")
+					if len(store.Logins) == 0 {
+						if !internal.PromptAddAccount(logger) {
+							logger.Info("No account was added. Exiting.")
+							return
+						}
+						acc = internal.CreateAccount(ctx, logger)
+						if err := tokenStore.SaveLogin(internal.CfLogin{
+							Email: acc.Email,
+							ID:    acc.ID,
+							Token: acc.Token,
+						}); err != nil {
+							logger.Fatal(err)
+						}
+					}
+				case internal.LoginSelect:
+					index := choice.Index
+					if choice.Index == -1 {
+						index = activeIndex
+					}
+					acc = internal.NewCfAccount(store.Logins[index].Token)
+					acc.ID = store.Logins[index].ID
+					acc.Email = store.Logins[index].Email
+				}
 			}
 		}
 


### PR DESCRIPTION
## Summary

Prevents the CLI from storing Cloudflare API tokens as plaintext in `store.json`.

The CLI now uses the operating system credential vault when available and an encrypted-file fallback on systems without a supported vault.

## Changes

### Native credential storage

- Uses the native credential store on:
  - Windows
  - macOS
  - Supported Linux desktop environments
- Stores credentials under the `bpb-wizard` service using the Cloudflare account ID.
- Records the selected backend in `store.json`.
- Reports an error if a previously selected credential vault becomes unavailable instead of silently changing storage backends.

### Encrypted fallback

For Termux, headless Linux, or systems without a usable credential vault:

- Encrypts tokens with AES-256-GCM.
- Derives the encryption key with Argon2id.
- Uses a random salt and a unique nonce for every token.
- Authenticates the store version and account ID as associated data.
- Requires a master password of at least eight characters.
- Keeps the password and derived key only in memory.
- Requires an interactive terminal so passwords are never read as visible input.

Only account email, account ID, active-account metadata, encryption parameters, nonce, and ciphertext are persisted.

### Legacy migration

- Detects existing plaintext token stores.
- Explains the migration and requests confirmation.
- Leaves the original file unchanged and exits when migration is declined.
- Verifies migrated vault credentials before replacing the plaintext store.
- Rolls back credentials and preserves the original file if migration fails.
- Restores any credential that existed before a failed migration.

### Removal and recovery

- Removes the corresponding vault credential or encrypted entry when an account is deleted.
- Allows users to erase an encrypted store after three failed password attempts.
- After erasure, asks whether the user wants to add a new account.
- Uses temporary files and platform-specific atomic replacement when updating store metadata.
- Applies restrictive permissions to the configuration directory and store files.

## Security scope

This PR protects API tokens saved locally by the CLI.

The generated Worker or Pages script still contains the Cloudflare token because BPB Panel uses it at runtime. Changing that behavior requires a separate redesign of the deployed panel’s credential architecture.

## Testing

Tests cover:

- Vault save, load, update, and deletion.
- Encrypted-file round trips.
- Unique nonce generation.
- Incorrect-password handling and reset.
- Ciphertext tamper detection.
- Native-vault unavailability.
- Successful, declined, encrypted, and partially failed migrations.
- Migration rollback and restoration of existing credentials.
- Verification that `store.json` does not contain plaintext tokens.
- Non-interactive terminal rejection.

## Validation

- `go test ./...`
- `go vet ./...`
- Cross-platform builds:
  - Linux: `amd64`, `arm64`, `arm`, `386`
  - Windows: `amd64`, `arm64`, `386`
  - macOS: `amd64`, `arm64`

## Dependency

This PR is based on and should be merged after the saved-token removal PR.